### PR TITLE
Add wizard and priest sample configs

### DIFF
--- a/docs/examples/priest_follow_config.txt
+++ b/docs/examples/priest_follow_config.txt
@@ -1,0 +1,49 @@
+# Sample OpenKore configuration for a support Priest
+# This configuration demonstrates how to make a Priest automatically
+# follow a chosen character and provide basic support skills.
+# Replace `LeaderName` with the name of the player you want to follow.
+
+######## Login options ########
+master        127.0.0.1
+server        0
+username      your_account
+password      your_password
+char          0
+serverType    rAthena
+
+######## Follow settings ########
+follow 1
+followTarget LeaderName
+followDistanceMin 3
+followDistanceMax 6
+followLostStep 12
+followSitAuto 0
+
+######## Party support skills ########
+# Heal party members below 70%% HP
+partySkill Heal {
+    lvl 10
+    target_hp < 70%
+    timeout 2
+}
+
+# Bless party members when they do not have Blessing
+partySkill Blessing {
+    lvl 10
+    target_whenStatusInactive Blessing
+    timeout 150
+}
+
+# Increase Agility if it is not active
+partySkill Increase AGI {
+    lvl 10
+    target_whenStatusInactive Increase AGI
+    timeout 120
+}
+
+# Resurrection when a party member is dead
+partySkill Resurrection {
+    lvl 4
+    target_dead 1
+    timeout 5
+}

--- a/docs/examples/wizard_monster_config.txt
+++ b/docs/examples/wizard_monster_config.txt
@@ -1,0 +1,43 @@
+# Sample OpenKore configuration for a damage Wizard
+# Demonstrates using different skills depending on the monster
+# Replace `YourAccount` details as needed and set up the wizard class.
+
+######## Login options ########
+master        127.0.0.1
+server        0
+username      your_account
+password      your_password
+char          0
+serverType    rAthena
+
+######## Attack skills ########
+# Cast Jupitel Thunder specifically on Siroma
+attackSkillSlot Jupitel Thunder {
+    lvl 10
+    dist 9
+    monsters Siroma
+    timeout 2
+}
+
+# Use Fire Bolt on Earth property monsters such as Les
+attackSkillSlot Fire Bolt {
+    lvl 10
+    dist 9
+    monsters Les
+    timeout 2
+}
+
+# Use Cold Bolt on Fire property monsters like Muscipular
+attackSkillSlot Cold Bolt {
+    lvl 10
+    dist 9
+    monsters Muscipular
+    timeout 2
+}
+
+# Default single target spell if none of the above match
+attackSkillSlot Lightning Bolt {
+    lvl 10
+    dist 9
+    timeout 2
+}


### PR DESCRIPTION
## Summary
- add new example configs for wizard monster-based skills and priest follower
- enable login options for ease of use

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688383e09bcc83278059dcbb53dfabd2